### PR TITLE
03: fix admin permissions

### DIFF
--- a/src/Critical.php
+++ b/src/Critical.php
@@ -187,7 +187,7 @@ class Critical extends Plugin
             'url' => $this->cpUrl('sections'),
         ];
 
-        if (Craft::$app->getUser()->getIsAdmin()) {
+        if (Craft::$app->getUser()->getIsAdmin() && Craft::$app->getConfig()->getGeneral()->allowAdminChanges) {
             $nav['subnav']['settings'] = [
                 'label' => $this->translate('Settings'),
                 'url' => $this->cpUrl('settings/general'),

--- a/src/controllers/ConfigController.php
+++ b/src/controllers/ConfigController.php
@@ -17,16 +17,6 @@ class ConfigController extends Controller
     protected array|int|bool $allowAnonymous = self::ALLOW_ANONYMOUS_NEVER;
 
     /**
-     * @inerhitdoc
-     */
-    public function beforeAction($action): bool
-    {
-        $this->requireAdmin();
-
-        return parent::beforeAction($action);
-    }
-
-    /**
      * critical-css-generator/settings/sections/edit action
      * loads the 'edit sections config' page.
      */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The "settings" link in the control panel navigation is now only visible to admins when the general configuration allows admin changes.

* **Changes**
  * Access control for certain configuration actions has been updated, which may affect who can access configuration options in the control panel.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->